### PR TITLE
Setup industrial CI

### DIFF
--- a/.github/workflows/isolated_library.yaml
+++ b/.github/workflows/isolated_library.yaml
@@ -1,4 +1,4 @@
-name: Devel environment build and test
+name: Build and test as an isolated library
 
 on:
   push: # this needs to run on the main and devel branches so that the cache is available to push_requests
@@ -6,7 +6,7 @@ on:
   pull_request:
     branches: [main, devel]
   schedule:
-    - cron: "0 6 * * *"
+    - cron: "0 6 * * 0"
   workflow_dispatch: # allow manually starting this workflow
 
 jobs:

--- a/.github/workflows/ros_package.yaml
+++ b/.github/workflows/ros_package.yaml
@@ -1,15 +1,15 @@
 # This config uses industrial_ci (https://github.com/ros-industrial/industrial_ci.git).
 # For troubleshooting, see README (https://github.com/ros-industrial/industrial_ci/blob/master/README.rst)
 
-name: Industrial CI
+name: ROS build test using Industrial CI
 
 on:
-  # push:
-  #   branches: [main, devel]
-  # pull_request:
-  #   branches: [main, devel]
-  # schedule:
-  #   - cron: "0 6 * * *"
+  push:
+    branches: [main, devel]
+  pull_request:
+    branches: [main, devel]
+  schedule:
+    - cron: "0 6 * * 0"
   workflow_dispatch:
 
 jobs:
@@ -21,6 +21,7 @@ jobs:
         ROS_DISTRO: [melodic]
         ROS_REPO: [main]
     env:
+      UPSTREAM_WORKSPACE: "github:glpuga/BehaviorTree.CPP#glpuga/ariac2022"
       ADDITIONAL_DEBS: python-catkin-lint
       PARALLEL_BUILDS: 8
       PARALLEL_TESTS: 1

--- a/.github/workflows/ros_package.yaml
+++ b/.github/workflows/ros_package.yaml
@@ -1,7 +1,7 @@
 # This config uses industrial_ci (https://github.com/ros-industrial/industrial_ci.git).
 # For troubleshooting, see README (https://github.com/ros-industrial/industrial_ci/blob/master/README.rst)
 
-name: ROS build test using Industrial CI
+name: Build and test as a ROS package with Industrial CI
 
 on:
   push:

--- a/.github/workflows/ros_package.yaml
+++ b/.github/workflows/ros_package.yaml
@@ -1,7 +1,7 @@
 # This config uses industrial_ci (https://github.com/ros-industrial/industrial_ci.git).
 # For troubleshooting, see README (https://github.com/ros-industrial/industrial_ci/blob/master/README.rst)
 
-name: Build and test as a ROS package with Industrial CI
+name: Build and test as a ROS package (Industrial CI)
 
 on:
   push:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,13 +68,13 @@ if(catkin_FOUND)
     set(ROSLINT_CPP_OPTS --extensions=h,hpp,cpp)
     roslint_cpp()
 
-    roslint_custom(catkin_lint --strict -W2 ${PROJECT_SOURCE_DIR})
+    roslint_custom(catkin_lint -W2 ${PROJECT_SOURCE_DIR})
     roslint_add_test()
   endif()
 
 else()
 
-  option(BUILD_TESTS "Build tests" ON)
+  option(${PROJECT_NAME}_ENABLE_TESTING "Build tests" ON)
 
   # Add our local modules folder to the search path for both <pkg>.cmake and
   # Find<pkg>.cmake files
@@ -98,16 +98,15 @@ else()
     ARCHIVE DESTINATION lib
     LIBRARY DESTINATION lib
     RUNTIME DESTINATION bin)
-  install(DIRECTORY include DESTINATION include)
 
   #
   # Testing
 
-  if(BUILD_TESTS)
+  if(${PROJECT_NAME}_ENABLE_TESTING)
     include(CTest)
     include(GoogleTest REQUIRED)
 
-    set(fast_test_target_name ${PROJECT_NAME}-fast-tests)
+    set(fast_test_target_name ${PROJECT_NAME}-islated-unit-tests)
     add_executable(${fast_test_target_name} tests/runner.cpp
                                             ${fast_test_files_list})
     target_link_libraries(${fast_test_target_name} ${PROJECT_NAME}

--- a/tests/fast_tests_behavior_tree_manager.cpp
+++ b/tests/fast_tests_behavior_tree_manager.cpp
@@ -159,7 +159,7 @@ TEST_F(BehaviorTreeManagerTests, HaltingATreeWorks)
 
   const auto run_time = end_time - start_time;
 
-  ASSERT_GE(thread_stopping_timestamp * 3 / 2, run_time);
+  ASSERT_GE(expected_runtime / 2, run_time);
 }
 
 }  // namespace


### PR DESCRIPTION
- Reenables Industrial CI after adding the dependency on the BehaviorTree.CPP fork with mocking as an upstream workspace in ICI.
- Enables triggers for the industrial CI workflow, including a weekly run.
- Disables the "--strict" flag in the caktin_lint run, since there are a few warnings due to the dual nature of the CMakelist file.