### PR TITLE
Fix that the checkout of test in isolated mode is shallow, and theref…

### DIFF
--- a/packages/GoogleTest.cmake
+++ b/packages/GoogleTest.cmake
@@ -2,7 +2,6 @@ include(FetchContent)
 FetchContent_Declare(googletest
   GIT_REPOSITORY    https://github.com/google/googletest.git
   GIT_TAG           c9461a9b55ba954df0489bab6420eb297bed846b    # tag: v1.10.0
-  GIT_SHALLOW       true
   GIT_PROGRESS      true
 )
 


### PR DESCRIPTION
…ore cannot checkout anything but GTest's head